### PR TITLE
feat(logging): use cls-hooked to allow for custom non-env based fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,9 @@ module.exports.main = wrap(main)
 
 * [logger](#module_logger)
     * [~init(params, [logger])](#module_logger..init) ⇒
-    * [~wrap(fn, params, [logger])](#module_logger..wrap) ⇒ <code>\*</code>
-    * [~logger(fn, [logger])](#module_logger..logger) ⇒ [<code>ActionFunction</code>](#module_wrap..ActionFunction)
+    * [~wrap(fn, params, [opts])](#module_logger..wrap) ⇒ <code>\*</code>
+    * [~trace(fn)](#module_logger..trace) ⇒ [<code>ActionFunction</code>](#module_wrap..ActionFunction)
+    * [~logger(fn, [opts])](#module_logger..logger) ⇒ [<code>ActionFunction</code>](#module_wrap..ActionFunction)
 
 <a name="module_logger..init"></a>
 
@@ -156,10 +157,9 @@ if not already present on `params.__ow_logger`.
 
 <a name="module_logger..wrap"></a>
 
-### logger~wrap(fn, params, [logger]) ⇒ <code>\*</code>
+### logger~wrap(fn, params, [opts]) ⇒ <code>\*</code>
 Takes a main OpenWhisk function and intitializes logging, by invoking [init](init).
-It logs invocation details on `trace` level before and after the actual action invocation.
-it also creates a bunyan logger and binds it to the `__ow_logger` params.
+It also creates a bunyan logger and binds it to the `__ow_logger` params.
 
 **Kind**: inner method of [<code>logger</code>](#module_logger)  
 **Returns**: <code>\*</code> - the return value of the action  
@@ -168,20 +168,38 @@ it also creates a bunyan logger and binds it to the `__ow_logger` params.
 | --- | --- | --- | --- |
 | fn | [<code>ActionFunction</code>](#module_wrap..ActionFunction) |  | original OpenWhisk action main function |
 | params | <code>\*</code> |  | OpenWhisk action params |
-| [logger] | <code>MultiLogger</code> | <code>rootLogger</code> | a helix multi logger. defaults to the helix                                            `rootLogger`. |
+| [opts] | <code>object</code> |  | Additional wrapping options |
+| [opts.fields] | <code>object</code> |  | Additional fields to log with the `ow` logging fields. |
+| [opts.logger] | <code>MultiLogger</code> | <code>rootLogger</code> | a helix multi logger. defaults to the helix                                            `rootLogger`. |
+
+<a name="module_logger..trace"></a>
+
+### logger~trace(fn) ⇒ [<code>ActionFunction</code>](#module_wrap..ActionFunction)
+Creates a tracer function that logs invocation details on `trace` level before and after the
+actual action invocation.
+
+**Kind**: inner method of [<code>logger</code>](#module_logger)  
+**Returns**: [<code>ActionFunction</code>](#module_wrap..ActionFunction) - an action function instrumented with tracing.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| fn | [<code>ActionFunction</code>](#module_wrap..ActionFunction) | original OpenWhisk action main function |
 
 <a name="module_logger..logger"></a>
 
-### logger~logger(fn, [logger]) ⇒ [<code>ActionFunction</code>](#module_wrap..ActionFunction)
+### logger~logger(fn, [opts]) ⇒ [<code>ActionFunction</code>](#module_wrap..ActionFunction)
 Wrap function that returns an OpenWhisk function that is enabled with logging.
 
 **Kind**: inner method of [<code>logger</code>](#module_logger)  
-**Returns**: [<code>ActionFunction</code>](#module_wrap..ActionFunction) - a new function with the same signature as your original main function  
+**Returns**: [<code>ActionFunction</code>](#module_wrap..ActionFunction) - a new function with the same signature as your original
+                                      main function  
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | fn | [<code>ActionFunction</code>](#module_wrap..ActionFunction) |  | original OpenWhisk action main function |
-| [logger] | <code>MultiLogger</code> | <code>rootLogger</code> | a helix multi logger. defaults to the helix                                            `rootLogger`. |
+| [opts] | <code>object</code> |  | Additional wrapping options |
+| [opts.fields] | <code>object</code> |  | Additional fields to log with the `ow` logging fields. |
+| [opts.logger] | <code>MultiLogger</code> | <code>rootLogger</code> | a helix multi logger. defaults to the helix                                            `rootLogger`. |
 
 **Example**  
 
@@ -193,6 +211,7 @@ async main(params) {
 }
 
 module.exports.main = wrap(main)
+  .with(logger.trace)
   .with(logger);
 ```
 <a name="module_middleware"></a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/openwhisk-action-utils",
-  "version": "2.7.0",
+  "version": "2.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -98,15 +98,6 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
       "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
       "dev": true
-    },
-    "@babel/runtime": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
-      "integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
-      "dev": true,
-      "requires": {
-        "regenerator-runtime": "^0.13.2"
-      }
     },
     "@babel/template": {
       "version": "7.4.4",
@@ -1251,12 +1242,6 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
-    "ast-metadata-inferer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.1.1.tgz",
-      "integrity": "sha512-hc9w8Qrgg9Lf9iFcZVhNjUnhrd2BBpTlyCnegPVvCe6O0yMrF57a6Cmh7k+xUsfUOMh9wajOL5AsGOBNEyTCcw==",
-      "dev": true
-    },
     "ast-types": {
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.2.tgz",
@@ -1272,6 +1257,14 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+    },
+    "async-hook-jl": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
+      "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
+      "requires": {
+        "stack-chain": "^1.3.7"
+      }
     },
     "atob-lite": {
       "version": "2.0.0",
@@ -1466,17 +1459,6 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
-    "browserslist": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.2.tgz",
-      "integrity": "sha512-uZavT/gZXJd2UTi9Ov7/Z340WOSQ3+m1iBVRUknf+okKxonL9P83S3ctiBDtuRmRu8PiCHjqyueqQ9HYlJhxiw==",
-      "dev": true,
-      "requires": {
-        "caniuse-lite": "^1.0.30001004",
-        "electron-to-chromium": "^1.3.295",
-        "node-releases": "^1.1.38"
-      }
-    },
     "btoa-lite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
@@ -1583,18 +1565,6 @@
           "dev": true
         }
       }
-    },
-    "caniuse-db": {
-      "version": "1.0.30001005",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001005.tgz",
-      "integrity": "sha512-MSRfm2N6FRDSpAJ00ipCuFe0CNink5JJOFzl4S7fLSBJdowhGq3uMxzkWGTjvvReo1PuWfK5YYJydJJ+9mJebw==",
-      "dev": true
-    },
-    "caniuse-lite": {
-      "version": "1.0.30001005",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001005.tgz",
-      "integrity": "sha512-g78miZm1Z5njjYR216a5812oPiLgV1ssndgGxITHWUopmjUrCswMisA0a2kSB7a0vZRox6JOKhM51+efmYN8Mg==",
-      "dev": true
     },
     "capture-stack-trace": {
       "version": "1.0.1",
@@ -1870,6 +1840,16 @@
         "is-plain-object": "^2.0.1",
         "kind-of": "^3.2.2",
         "shallow-clone": "^0.1.2"
+      }
+    },
+    "cls-hooked": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
+      "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
+      "requires": {
+        "async-hook-jl": "^1.7.6",
+        "emitter-listener": "^1.0.1",
+        "semver": "^5.4.1"
       }
     },
     "co": {
@@ -2155,12 +2135,11 @@
       },
       "dependencies": {
         "handlebars": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.0.tgz",
-          "integrity": "sha512-yss1ZbupTpRfe86dpM1abxnnSfxa6eIRn3laqBPIgRYy87qgYtX6xinSOeybjYo/4AVzdTTWK5Kr06A6AllxJg==",
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+          "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
           "dev": true,
           "requires": {
-            "eslint-plugin-compat": "^3.3.0",
             "neo-async": "^2.6.0",
             "optimist": "^0.6.1",
             "source-map": "^0.6.1",
@@ -2546,9 +2525,9 @@
       },
       "dependencies": {
         "handlebars": {
-          "version": "4.5.1",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
-          "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+          "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
           "dev": true,
           "requires": {
             "neo-async": "^2.6.0",
@@ -2653,12 +2632,6 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
-    "electron-to-chromium": {
-      "version": "1.3.296",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.296.tgz",
-      "integrity": "sha512-s5hv+TSJSVRsxH190De66YHb50pBGTweT9XGWYu/LMR20KX6TsjFzObo36CjVAzM+PUeeKSBRtm/mISlCzeojQ==",
-      "dev": true
-    },
     "elegant-spinner": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
@@ -2669,6 +2642,14 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-2.0.4.tgz",
       "integrity": "sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ=="
+    },
+    "emitter-listener": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
+      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
+      "requires": {
+        "shimmer": "^1.2.0"
+      }
     },
     "emoji-regex": {
       "version": "7.0.3",
@@ -3117,29 +3098,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
-      }
-    },
-    "eslint-plugin-compat": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-3.3.0.tgz",
-      "integrity": "sha512-QCgYy3pZ+zH10dkBJus1xER0359h1UhJjufhQRqp9Owm6BEoLZeSqxf2zINwL1OGao9Yc96xPYIW3nQj5HUryg==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.4.5",
-        "ast-metadata-inferer": "^0.1.1",
-        "browserslist": "^4.6.3",
-        "caniuse-db": "^1.0.30000977",
-        "lodash.memoize": "4.1.2",
-        "mdn-browser-compat-data": "^0.0.84",
-        "semver": "^6.1.2"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
@@ -4038,9 +3996,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.1.tgz",
-      "integrity": "sha512-c0HoNHzDiHpBt4Kqe99N8tdLPKAnGCQ73gYMPWtAYM4PwGnf7xl8PBUHJqh9ijlzt2uQKaSRxbXRt+rZ7M2/kA==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -4147,9 +4105,9 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
-      "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
       "dev": true,
       "requires": {
         "agent-base": "^4.3.0",
@@ -5323,12 +5281,6 @@
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
       "dev": true
     },
-    "lodash.memoize": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-      "dev": true
-    },
     "lodash.omit": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
@@ -5559,15 +5511,6 @@
           "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
           "dev": true
         }
-      }
-    },
-    "mdn-browser-compat-data": {
-      "version": "0.0.84",
-      "resolved": "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.84.tgz",
-      "integrity": "sha512-fAznuGNaQMQiWLVf+gyp33FaABTglYWqMT7JqvH+4RZn2UQPD12gbMqxwP9m0lj8AAbNpu5/kD6n4Ox1SOffpw==",
-      "dev": true,
-      "requires": {
-        "extend": "3.0.2"
       }
     },
     "mdurl": {
@@ -6202,23 +6145,6 @@
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
       "dev": true
     },
-    "node-releases": {
-      "version": "1.1.39",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.39.tgz",
-      "integrity": "sha512-8MRC/ErwNCHOlAFycy9OPca46fQYUjbJRDcZTHVWIGXIjYLM73k70vv3WkYutVnM4cCo4hE0MqBVVZjP6vjISA==",
-      "dev": true,
-      "requires": {
-        "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
-      }
-    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -6733,34 +6659,6 @@
             "string-width": "^2.1.1"
           }
         },
-        "cliui": {
-          "version": "4.1.0",
-          "resolved": false,
-          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-              "dev": true
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": false,
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              }
-            }
-          }
-        },
         "clone": {
           "version": "1.0.4",
           "resolved": false,
@@ -7018,12 +6916,6 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
-          "dev": true
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
         },
         "decode-uri-component": {
@@ -7309,15 +7201,6 @@
           "integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA==",
           "dev": true
         },
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
         "flush-write-stream": {
           "version": "1.0.3",
           "resolved": false,
@@ -7569,9 +7452,9 @@
           }
         },
         "get-caller-file": {
-          "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
           "dev": true
         },
         "get-stream": {
@@ -7726,8 +7609,7 @@
         },
         "https-proxy-agent": {
           "version": "2.2.2",
-          "resolved": false,
-          "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+          "resolved": "",
           "dev": true,
           "requires": {
             "agent-base": "^4.3.0",
@@ -7822,12 +7704,6 @@
             "validate-npm-package-license": "^3.0.1",
             "validate-npm-package-name": "^3.0.0"
           }
-        },
-        "invert-kv": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-          "dev": true
         },
         "ip": {
           "version": "1.1.5",
@@ -8043,15 +7919,6 @@
           "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=",
           "dev": true
         },
-        "lcid": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-          "dev": true,
-          "requires": {
-            "invert-kv": "^1.0.0"
-          }
-        },
         "libcipm": {
           "version": "4.0.4",
           "resolved": "https://registry.npmjs.org/libcipm/-/libcipm-4.0.4.tgz",
@@ -8251,16 +8118,6 @@
             "yargs": "^11.0.0"
           }
         },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
         "lock-verify": {
           "version": "2.1.0",
           "resolved": false,
@@ -8414,15 +8271,6 @@
           "integrity": "sha512-UakVLFjKkbbUwNWJ2frVLnnAtbb7D7DsloxRd3s/gDpI8rdv8W5Hp3NaDb+POBI1fQdeussER6NB8vpcRURvlg==",
           "dev": true
         },
-        "mem": {
-          "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        },
         "mime-db": {
           "version": "1.35.0",
           "resolved": false,
@@ -8437,12 +8285,6 @@
           "requires": {
             "mime-db": "~1.35.0"
           }
-        },
-        "mimic-fn": {
-          "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-          "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
@@ -8820,17 +8662,6 @@
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true
         },
-        "os-locale": {
-          "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-          "dev": true,
-          "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
-          }
-        },
         "os-tmpdir": {
           "version": "1.0.2",
           "resolved": false,
@@ -8851,30 +8682,6 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-          "dev": true
-        },
-        "p-limit": {
-          "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
-          "dev": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "dev": true,
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
           "dev": true
         },
         "package-json": {
@@ -9310,15 +9117,9 @@
             "uuid": "^3.3.2"
           }
         },
-        "require-directory": {
-          "version": "2.1.1",
-          "resolved": false,
-          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-          "dev": true
-        },
         "require-main-filename": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
           "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
           "dev": true
         },
@@ -10005,12 +9806,6 @@
             "isexe": "^2.0.0"
           }
         },
-        "which-module": {
-          "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-          "dev": true
-        },
         "wide-align": {
           "version": "1.1.2",
           "resolved": false,
@@ -10049,29 +9844,6 @@
           "dev": true,
           "requires": {
             "errno": "~0.1.7"
-          }
-        },
-        "wrap-ansi": {
-          "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-          "dev": true,
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
-          },
-          "dependencies": {
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            }
           }
         },
         "wrappy": {
@@ -10116,16 +9888,16 @@
           "dev": true
         },
         "yargs": {
-          "version": "11.0.0",
-          "resolved": false,
-          "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.1.tgz",
+          "integrity": "sha512-PRU7gJrJaXv3q3yQZ/+/X6KBswZiaQ+zOmdprZcouPYtQgvNU35i+68M4b1ZHLZtYFT5QObFLV+ZkmJYcwKdiw==",
           "dev": true,
           "requires": {
             "cliui": "^4.0.0",
             "decamelize": "^1.1.1",
             "find-up": "^2.1.0",
             "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
+            "os-locale": "^3.1.0",
             "require-directory": "^2.1.1",
             "require-main-filename": "^1.0.1",
             "set-blocking": "^2.0.0",
@@ -10137,7 +9909,7 @@
           "dependencies": {
             "y18n": {
               "version": "3.2.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
               "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
               "dev": true
             }
@@ -10145,7 +9917,7 @@
         },
         "yargs-parser": {
           "version": "9.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
           "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
           "dev": true,
           "requires": {
@@ -11207,12 +10979,6 @@
         }
       }
     },
-    "regenerator-runtime": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
-      "dev": true
-    },
     "regexpp": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
@@ -11874,6 +11640,11 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
+    "shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -12478,6 +12249,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "stack-chain": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+      "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
     },
     "statuses": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@adobe/helix-log": "4.0.0",
     "bunyan": "^1.8.12",
+    "cls-hooked": "^4.2.2",
     "dotenv": "^8.2.0",
     "openwhisk": "^3.20.0",
     "serverless-http": "^2.3.0"

--- a/src/logger.d.ts
+++ b/src/logger.d.ts
@@ -20,6 +20,22 @@ import { MultiLogger } from '@adobe/helix-log';
 declare interface BunyanLogger {}
 
 /**
+ * Options for the wrap functions
+ */
+declare interface WrapOptions {
+
+  /**
+   * Helix multi logger. defaults to the helix `rootLogger`.
+   */
+  logger?: MultiLogger,
+
+  /**
+   * Additional fields to log with the `ow` logging fields.
+   */
+  fields?: object,
+}
+
+/**
  * Wrap function that returns an OpenWhisk function that is enabled with logging.
  *
  * @example <caption></caption>
@@ -37,11 +53,10 @@ declare interface BunyanLogger {}
  *
  * @function logger
  * @param {ActionFunction} fn - original OpenWhisk action main function
- * @param {MultiLogger} [logger=rootLogger] - a helix multi logger. defaults to the helix
- *                                            `rootLogger`.
+ * @param {WrapOptions} [opts] - optional options.
  * @returns {ActionFunction} a new function with the same signature as your original main function
  */
-export declare function logger(fn: ActionFunction, logger: MultiLogger): ActionFunction;
+export declare function logger(fn: ActionFunction, opts: WrapOptions): ActionFunction;
 
 export declare namespace logger {
   /**
@@ -57,14 +72,21 @@ export declare namespace logger {
 
   /**
    * Takes a main OpenWhisk function and intitializes logging, by invoking {@link init}.
-   * It logs invocation details on `trace` level before and after the actual action invocation.
    * it also creates a bunyan logger and binds it to the `__ow_logger` params.
    *
    * @param {ActionFunction} fn - original OpenWhisk action main function
    * @param {*} params - OpenWhisk action params
-   * @param {MultiLogger} [logger=rootLogger] - a helix multi logger. defaults to the helix
-   *                                            `rootLogger`.
+   * @param {WrapOptions} [opts] - optional options.
    * @returns {*} the return value of the action
    */
-  export function wrap(fn: ActionFunction, params: object, logger: MultiLogger): object;
+  export function wrap(fn: ActionFunction, params: object, opts: WrapOptions): object;
+
+  /**
+   * Creates a tracer function that logs invocation details on `trace` level before and after the
+   * actual action invocation.
+   *
+   * @param {ActionFunction} fn - original OpenWhisk action main function
+   * @returns {ActionFunction} an action function instrumented with tracing.
+   */
+  export function trace(fn: ActionFunction): ActionFunction;
 }


### PR DESCRIPTION
BREAKING CHANGE: the wrap() function no longer sets up tracing. this moved
                 to logger.trace
                 Further more, the wrap() and wrapper() signature has changed
                 using an option object instead of arguments.

---

usage:

```js
const { logger, wrap } = require('@adobe/openwhisk-action-utils'};

async main(params) {
  //…my action code…
}

module.exports.main = wrap(main)
  .with(logger.trace)
  .with(logger, { fields: { x-request-id: 'foo' });
```

maybe we should export the cls context, so actions can add fields dynamically.

alternatively you can do:

```js
const { logger, wrap } = require('@adobe/openwhisk-action-utils'};
const { getNamesapce } = require('cls-hooked');

async main(params) {
  //…my action code…
}

function injectfields(fn) {
  return (params) => {
     const ow = getNamespace('ow-util-logger').get('ow-fields');
     ow['x-request-id'] = '....';
     return fn(params);
  }
}

module.exports.main = wrap(main)
  .with(logger.trace)
  .with(injectFields)
  .with(logger);
```


