### PR TITLE
feat(expressify): improve expressify so that no params needs to be pa…

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 <dt><a href="#module_expressify">expressify</a></dt>
 <dd><p>Helper to turn a OpenWhisk web action into a express request which can be handled with normal
 express handlers.</p>
+<p>Expressify maps the query and action params to <code>req.query</code>. The original action params are
+available under <code>req.owActionParams</code>.</p>
 <p><strong>Usage:</strong></p>
 <pre><code class="language-js">const { expressify, errorHandler } = require(&#39;@adobe/openwhisk-action-utils&#39;);
 
@@ -45,8 +47,8 @@ async function main(params) {
   const app = express();
   app.use(logRequest(log));
   app.use(cacheControl());
-  app.get(&#39;/&#39;, asyncHandler(startHandler, params));
-  app.get(&#39;/ping&#39;, asyncHandler(pingHandler, params));
+  app.get(&#39;/&#39;, asyncHandler(startHandler));
+  app.get(&#39;/ping&#39;, asyncHandler(pingHandler));
   app.use(errorHandler(log));
 
   return expressify(app)(params);
@@ -82,6 +84,9 @@ stream to the given helix logger.</p>
 ## expressify
 Helper to turn a OpenWhisk web action into a express request which can be handled with normal
 express handlers.
+
+Expressify maps the query and action params to `req.query`. The original action params are
+available under `req.owActionParams`.
 
 **Usage:**
 
@@ -133,8 +138,8 @@ async function main(params) {
   const app = express();
   app.use(logRequest(log));
   app.use(cacheControl());
-  app.get('/', asyncHandler(startHandler, params));
-  app.get('/ping', asyncHandler(pingHandler, params));
+  app.get('/', asyncHandler(startHandler));
+  app.get('/ping', asyncHandler(pingHandler));
   app.use(errorHandler(log));
 
   return expressify(app)(params);
@@ -146,8 +151,7 @@ async function main(params) {
     * [~errorHandler(log)](#module_middleware..errorHandler) ⇒ <code>ExpressMiddleware</code>
     * [~cacheControl([value])](#module_middleware..cacheControl) ⇒ <code>ExpressMiddleware</code>
     * [~logRequest(logger)](#module_middleware..logRequest) ⇒ <code>ExpressMiddleware</code>
-    * [~asyncHandler(fn, params)](#module_middleware..asyncHandler) ⇒ <code>ExpressMiddleware</code>
-    * [~createBunyanLogger([logger])](#module_middleware..createBunyanLogger) ⇒ <code>BunyanLogger</code>
+    * [~asyncHandler(fn)](#module_middleware..asyncHandler) ⇒ <code>ExpressMiddleware</code>
     * [~ActionMiddlewareFunction](#module_middleware..ActionMiddlewareFunction) : <code>function</code>
 
 <a name="module_middleware..errorHandler"></a>
@@ -208,8 +212,8 @@ app.use(logRequest(log));
 ```
 <a name="module_middleware..asyncHandler"></a>
 
-### middleware~asyncHandler(fn, params) ⇒ <code>ExpressMiddleware</code>
-Wraps the route middleware so it can bind the params and catch potential promise rejections
+### middleware~asyncHandler(fn) ⇒ <code>ExpressMiddleware</code>
+Wraps the route middleware so it can catch potential promise rejections
 during the async invocation.
 
 **Kind**: inner method of [<code>middleware</code>](#module_middleware)  
@@ -217,21 +221,7 @@ during the async invocation.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| fn | [<code>ActionMiddlewareFunction</code>](#module_middleware..ActionMiddlewareFunction) | an extended express middleware function |
-| params | <code>\*</code> | Action params to be pass to the handler. |
-
-<a name="module_middleware..createBunyanLogger"></a>
-
-### middleware~createBunyanLogger([logger]) ⇒ <code>BunyanLogger</code>
-Sets up a bunyan logger suitable to use with an openwhisk action. The bunyan logger will
-stream to the given helix logger.
-
-**Kind**: inner method of [<code>middleware</code>](#module_middleware)  
-**Returns**: <code>BunyanLogger</code> - A bunyan logger  
-
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| [logger] | <code>Logger</code> | <code>rootLogger</code> | a helix multi logger. defaults to the helix `rootLogger`. |
+| fn | <code>ExpressMiddleware</code> | an extended express middleware function |
 
 <a name="module_middleware..ActionMiddlewareFunction"></a>
 

--- a/src/middleware.d.ts
+++ b/src/middleware.d.ts
@@ -31,19 +31,6 @@ declare interface ExpressResponse {}
 declare type ExpressMiddleware = (req: ExpressRequest, res: ExpressResponse, next: ExpressMiddleware) => void;
 
 /**
- * Extended middleware function to be use with the {@link asyncHandler}.
- *
- * @see https://expressjs.com/en/4x/api.html#middleware-callback-function-examples
- *
- * @callback ActionMiddlewareFunction
- * @param {*} params The action params
- * @param {ExpressRequest} req The express request
- * @param {ExpressResponse} res The express response
- * @param {ExpressMiddleware} next The next handler in chain.
- */
-export declare type ActionMiddlewareFunction = (params: object, req: ExpressRequest, res: ExpressResponse, next: ExpressMiddleware) => void;
-
-/**
  * Error handler. Reports errors that happen during the request processing and responds
  * with a `500` if not already set.
  *
@@ -91,11 +78,10 @@ export declare function cacheControl(value: string): ExpressMiddleware;
 export declare function logRequest(logger: BunyanLogger): ExpressMiddleware;
 
 /**
- * Wraps the route middleware so it can bind the params and catch potential promise rejections
- * during the async invocation.
+ * Wraps the route middleware so it can catch potential promise rejections during the async
+ * invocation.
  *
- * @param {ActionMiddlewareFunction} fn an extended express middleware function
- * @param {*} params Action params to be pass to the handler.
+ * @param {ExpressMiddleware} fn an extended express middleware function
  * @returns {ExpressMiddleware} an express middleware function.
  */
-export declare function asyncHandler(fn: ActionMiddlewareFunction, params: object): ExpressMiddleware;
+export declare function asyncHandler(fn: ExpressMiddleware): ExpressMiddleware;

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -30,8 +30,8 @@ const crypto = require('crypto');
  *   const app = express();
  *   app.use(logRequest(log));
  *   app.use(cacheControl());
- *   app.get('/', asyncHandler(startHandler, params));
- *   app.get('/ping', asyncHandler(pingHandler, params));
+ *   app.get('/', asyncHandler(startHandler));
+ *   app.get('/ping', asyncHandler(pingHandler));
  *   app.use(errorHandler(log));
  *
  *   return expressify(app)(params);
@@ -151,15 +151,14 @@ function logRequest(logger) {
 }
 
 /**
- * Wraps the route middleware so it can bind the params and catch potential promise rejections
+ * Wraps the route middleware so it can catch potential promise rejections
  * during the async invocation.
  *
- * @param {module:middleware~ActionMiddlewareFunction} fn an extended express middleware function
- * @param {*} params Action params to be pass to the handler.
+ * @param {ExpressMiddleware} fn an extended express middleware function
  * @returns {ExpressMiddleware} an express middleware function.
  */
-function asyncHandler(fn, params) {
-  return (req, res, next) => (Promise.resolve(fn(params, req, res, next)).catch(next));
+function asyncHandler(fn) {
+  return (req, res, next) => (Promise.resolve(fn(req, res, next)).catch(next));
 }
 
 module.exports = {

--- a/test/expressify.test.js
+++ b/test/expressify.test.js
@@ -22,29 +22,35 @@ describe('Expressify', () => {
   it('handles simple get', async () => {
     const app = express();
     app.get('/ping', (req, res) => {
-      res.send('ok');
+      const dump = {
+        query: req.query,
+        test: req.owActionParams.__ow_path,
+      };
+      res.send(`${JSON.stringify(dump)}`);
     });
 
     const params = {
       __ow_path: '/ping',
       __ow_method: 'get',
       __ow_headers: {},
+      __ow_query: 'a=1&a=2',
+      foo: '42',
+      SUPER_SECRET: 'foo',
     };
 
     const result = await expressify(app)(params);
 
     assert.deepEqual(result, {
-      body: 'ok',
+      body: '{"query":{"foo":"42","a":["1","2"]},"test":"/ping"}',
       headers: {
-        'content-length': '2',
+        'content-length': '51',
         'content-type': 'text/html; charset=utf-8',
-        etag: 'W/"2-eoX0dku9ba8cNUXvu/DyeabcC+s"',
+        etag: 'W/"33-zMD3V1aagE/Fph2VK4mzE96IU9s"',
         'x-powered-by': 'Express',
       },
       statusCode: 200,
     });
   });
-
 
   // eslint-disable-next-line no-restricted-syntax
   for (const __ow_path of [null, undefined, '', 'missing']) {

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -262,15 +262,14 @@ describe('Middleware', () => {
 
   it('Async handler can pass in params', async () => {
     const app = express();
-    app.get('/', asyncHandler(async (params, req, res) => {
-      res.send(`result is ${params.result}`);
-    }, {
-      result: 42,
+    app.get('/', asyncHandler(async (req, res) => {
+      res.send(`result is ${req.query.result}`);
     }));
     const params = {
       __ow_path: '/',
       __ow_method: 'get',
       __ow_headers: {},
+      result: 42,
     };
     const result = await expressify(app)(params);
     assert.deepEqual(result, {


### PR DESCRIPTION
…ssed to the handlers

fixes #54

BREAKING CHANGE: The async handler now takes a normal express middleware function and
no longer passes the `params`. most of the params and the __ow_query are available
via `req.query`. the original action params are available via `req.owActionParams`.
Note that the ALL_UPPERCASE params are not stored in `req.query` as they most likely
contain secrets and are passed via default action params.